### PR TITLE
Fixes a bug where user had to click outside search box to trigger a selection

### DIFF
--- a/wet-bulb-temperature-app/src/components/HelloWorld.vue
+++ b/wet-bulb-temperature-app/src/components/HelloWorld.vue
@@ -189,9 +189,11 @@ export default {
             @input="searchCities"
             no-data-text=""
             v-model="selectedCity"
-            @change="onCitySelect"
+            @click:option="onCitySelect"
+            @update:model-value="onCitySelect"
             no-filter
             :menu-props="auto"
+            close-on-click
           ></v-autocomplete>
         </v-row>
 


### PR DESCRIPTION
This bug rendered the app useless on mobile screens.

Now, whenever a user selects an option from the dropdown, it is selected immediately. 